### PR TITLE
[Fixed] Increment Selection package conflict

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -14,7 +14,7 @@
     {"caption":"TextCommands: Integer Sequence", "command":"integer_sequence"},
     {"caption":"TextCommands: Decimal To Hex", "command":"decimal_to_hex"},
     {"caption":"TextCommands: Hex To Decimal", "command":"hex_to_decimal"},
-    {"caption":"TextCommands: Increment Selection", "command":"increment_selection"},
+    {"caption":"TextCommands: Increment Selection", "command":"text_commands_increment_selection"},
     {"caption":"TextCommands: Decrement Selection", "command":"decrement_selection"},
     {"caption":"TextCommands: Selection Length", "command":"selection_length"},
     {"caption":"TextCommands: Sort Text", "command":"sort_text"},

--- a/numeric.py
+++ b/numeric.py
@@ -38,13 +38,14 @@ except ImportError:
 
 
 class IntegerSequenceCommand(bases.PerIntegerTextCommand):
+
     def pre(self):
         super(IntegerSequenceCommand, self).pre()
         self.ind = 0
 
     def per_int(self, intval):
         self.ind += 1
-        return str(self.ind-1)
+        return str(self.ind - 1)
 
 """
     Converts selected hex numbers into decimal equivalents
@@ -52,6 +53,7 @@ class IntegerSequenceCommand(bases.PerIntegerTextCommand):
 
 
 class HexToDecimalCommand(bases.PerWordTextCommand):
+
     def per_word(self, text):
         try:
             int_val = int(text, base=16)
@@ -66,6 +68,7 @@ class HexToDecimalCommand(bases.PerWordTextCommand):
 
 
 class DecimalToHexCommand(bases.PerIntegerTextCommand):
+
     def per_int(self, num):
         return num_to_hex(num)
 
@@ -74,7 +77,8 @@ class DecimalToHexCommand(bases.PerIntegerTextCommand):
 """
 
 
-class IncrementSelectionCommand(bases.PerIntegerTextCommand):
+class TextCommandsIncrementSelectionCommand(bases.PerIntegerTextCommand):
+
     def per_int(self, num):
         num += 1
         return str(num)
@@ -85,6 +89,7 @@ class IncrementSelectionCommand(bases.PerIntegerTextCommand):
 
 
 class DecrementSelectionCommand(bases.PerIntegerTextCommand):
+
     def per_int(self, num):
         num -= 1
         return str(num)


### PR DESCRIPTION
Package Increment Selection have the [**same name of command**](https://github.com/yulanggong/IncrementSelection/blob/master/IncrementSelection.py#L3) — `increment_selection`. Commands run different actions. It would be nice to have another command name.

Thanks.